### PR TITLE
docs: add fit summary, fix quantile description, capitalize method first words

### DIFF
--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -302,6 +302,7 @@ inline Kde1d::Kde1d(const interp::InterpolationGrid& grid,
 {
 }
 
+//! Fits the kernel density estimate to data.
 //! @param x vector of observations
 //! @param weights vector of weights for each observation (optional).
 inline void
@@ -388,7 +389,7 @@ Kde1d::fit(const Eigen::VectorXd& x, const Eigen::VectorXd& weights)
   bandwidth_ = bandwidth_ / multiplier_;
 }
 
-//! computes the pdf of the kernel density estimate by interpolation.
+//! Computes the pdf of the kernel density estimate by interpolation.
 //! @param x vector of evaluation points.
 //! @param check_fitted an optional logical to bypass the check.
 //! @return a vector of pdf values.
@@ -445,7 +446,7 @@ Kde1d::pdf_zi(const Eigen::VectorXd& x) const
     .select(prob0_ * ones.array(), (1 - prob0_) * pdf_continuous(x).array());
 }
 
-//! computes the cdf of the kernel density estimate by numerical
+//! Computes the cdf of the kernel density estimate by numerical
 //! integration.
 //! @param x vector of evaluation points.
 //! @param check_fitted an optional logical to bypass the check.
@@ -506,8 +507,8 @@ Kde1d::cdf_zi(const Eigen::VectorXd& x) const
   return prob0_ * zi + (1 - prob0_) * (prob0_ < 1 ? cdf_continuous(x) : zeros);
 }
 
-//! computes the cdf of the kernel density estimate by numerical inversion.
-//! @param x vector of evaluation points.
+//! Computes the quantile function by numerical inversion of the cdf.
+//! @param x vector of evaluation points (probabilities in ``(0, 1)``).
 //! @param check_fitted an optional logical to bypass the check.
 //! @return a vector of quantiles.
 inline Eigen::VectorXd
@@ -581,7 +582,7 @@ Kde1d::quantile_zi(const Eigen::VectorXd& x) const
   return qs;
 }
 
-//! simulates data from the model.
+//! Simulates data from the fitted density.
 //! @param n the number of observations to simulate.
 //! @param seeds an optional vector of seeds.
 //! @param check_fitted an optional logical to bypass the check.


### PR DESCRIPTION
## Summary

Tweaks the Doxygen comments on the inline definitions of `Kde1d::fit`, `Kde1d::pdf`, `Kde1d::cdf`, `Kde1d::quantile`, `Kde1d::simulate` so that the libclang docstring extraction used by [pyvinecopulib](https://github.com/vinecopulib/pyvinecopulib) produces accurate, consistently-styled Python docstrings.

- `fit` was missing a summary line (extracted docstring had only the `Parameters` section).
- `quantile` summary said *"computes the cdf of the kernel density estimate by numerical inversion"* — it computes the quantile (inverse CDF), not the CDF.
- `pdf`, `cdf`, `simulate` summaries now start with a capital letter to match the canonical C++ comment style elsewhere in vinecopulib.

Comment-only; no behavioural change.

## Test plan

- [x] Re-extraction with pyvinecopulib's libclang pipeline produces the corrected text in `src/include/docstr.hpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)