### PR TITLE
Numerical repairs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: Build Status
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/include/kde1d/interpolation.hpp
+++ b/include/kde1d/interpolation.hpp
@@ -93,7 +93,7 @@ InterpolationGrid::interpolate(const Eigen::VectorXd& x) const
     if (xev <= 0) {
       return values_(k) * std::exp(-0.5 * xev * xev);
     } else if (xev >= 1) {
-      return values_(k + 1) * std::exp(-0.5 * xev * xev);
+      return values_(k + 1) * std::exp(-0.5 * (xev - 1) * (xev - 1));
     }
 
     return cubic_poly(xev, find_cell_coefs(k));

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -648,6 +648,8 @@ Kde1d::fit_lp(const Eigen::VectorXd& x,
     x, bandwidth_, grid_points(0), grid_points(m - 1), weights, m - 1);
   Eigen::VectorXd f0 = kde_fft.kde_drv(0);
   Eigen::VectorXd f1(f0.size()), f2(f0.size());
+  const double density_floor =
+    std::numeric_limits<double>::epsilon() * f0.cwiseAbs().maxCoeff();
 
   Eigen::VectorXd wbin = Eigen::VectorXd::Ones(m);
   if (weights.size()) {
@@ -688,9 +690,13 @@ Kde1d::fit_lp(const Eigen::VectorXd& x,
   res.col(0) = res.col(0).array() * (-0.5 * b.array().pow(2) * S.array()).exp();
 
   for (size_t k = 0; k < m; k++) {
+    if (!std::isfinite(f0(k)) || f0(k) <= density_floor) {
+      res.row(k).setZero();
+      continue;
+    }
     res(k, 1) =
       calculate_infl(x.size(), f0(k), f1(k), f2(k), bandwidth_, S(k), wbin(k));
-    if (std::isnan(res(k, 0)))
+    if (!std::isfinite(res(k, 0)) || res(k, 0) < 0.0)
       res.row(k).setZero();
   }
 

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -509,7 +509,8 @@ Kde1d::cdf_discrete(const Eigen::VectorXd& x) const
     } else if (xx >= ub) {
       return 1.0;
     } else {
-      return f_cum(static_cast<size_t>(xx - lb));
+      return std::min(
+        1.0, std::max(0.0, f_cum(static_cast<size_t>(xx - lb))));
     };
   });
 }

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -427,7 +427,12 @@ Kde1d::pdf_continuous(const Eigen::VectorXd& x) const
 {
   Eigen::VectorXd fhat = grid_.interpolate(x);
   auto trunc = [](const double& xx) { return std::max(xx, 0.0); };
-  return tools::unaryExpr_or_nan(fhat, trunc);
+  fhat = tools::unaryExpr_or_nan(fhat, trunc);
+  if (!std::isnan(xmin_))
+    fhat = (x.array() < xmin_).select(0.0, fhat);
+  if (!std::isnan(xmax_))
+    fhat = (x.array() > xmax_).select(0.0, fhat);
+  return fhat;
 }
 
 inline Eigen::VectorXd

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -389,9 +389,11 @@ Kde1d::fit(const Eigen::VectorXd& x, const Eigen::VectorXd& weights)
   }
 
   // calculate effective degrees of freedom
-  interp::InterpolationGrid infl_grid(
-      grid_points, fitted.col(1).cwiseMin(3.0).cwiseMax(0), 0);
-  Eigen::VectorXd influences = infl_grid.interpolate(xx).array();
+  Eigen::VectorXd influences = fitted.col(1).cwiseMin(3.0).cwiseMax(0);
+  if (std::isnan(xmin_) && !std::isnan(xmax_))
+    influences.reverseInPlace();
+  interp::InterpolationGrid infl_grid(grid_points, influences, 0);
+  influences = infl_grid.interpolate(xx).array();
   edf_ = influences.sum() + static_cast<double>(prob0_ > 0);
 
   // store bandwidth in standardized format

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -363,7 +363,7 @@ Kde1d::fit(const Eigen::VectorXd& x, const Eigen::VectorXd& weights)
   // correct estimated density for transformation
   Eigen::VectorXd values = boundary_correct(grid_points, fitted.col(0));
 
-  // move boundary points to xmin/xmax
+  // order grid points from left to right
   grid_points = finalize_grid(grid_points);
 
   // construct interpolation grid
@@ -822,25 +822,47 @@ Kde1d::construct_grid_points(const Eigen::VectorXd& x)
 {
   Eigen::VectorXd rng(2);
   rng << x.minCoeff(), x.maxCoeff();
-  if (std::isnan(xmin_) && std::isnan(xmax_)) {
+  if (type_ == VarType::discrete) {
+    // Discrete estimates use jittered observations without transformation.
+  } else if (std::isnan(xmin_) && std::isnan(xmax_)) {
     rng(0) -= 4 * bandwidth_;
+    rng(1) += 4 * bandwidth_;
+  } else if (!std::isnan(xmin_) && !std::isnan(xmax_)) {
+    Eigen::VectorXd boundaries(2);
+    boundaries << xmin_, xmax_;
+    rng = boundary_transform(boundaries);
+  } else {
+    rng(0) = boundary_transform(Eigen::VectorXd::Constant(
+      1, std::isnan(xmin_) ? xmax_ : xmin_))(0);
     rng(1) += 4 * bandwidth_;
   }
   auto zgrid = Eigen::VectorXd::LinSpaced(grid_size_ + 1, rng(0), rng(1));
-  return boundary_transform(zgrid, true);
+  Eigen::VectorXd grid_points = boundary_transform(zgrid, true);
+
+  // Avoid round-off at finite support boundaries before evaluating the fit.
+  if (type_ != VarType::discrete) {
+    if (!std::isnan(xmin_))
+      grid_points(0) = xmin_;
+    if (!std::isnan(xmax_))
+      grid_points(std::isnan(xmin_) ? 0 : grid_size_) = xmax_;
+  }
+
+  return grid_points;
 }
 
-//! moves the boundary points of the grid to xmin/xmax (if non-NaN).
+//! orders grid points from left to right.
 //! @param grid_points the grid points.
 inline Eigen::VectorXd
 Kde1d::finalize_grid(Eigen::VectorXd& grid_points)
 {
   if (std::isnan(xmin_) && !std::isnan(xmax_))
     grid_points.reverseInPlace();
-  if (!std::isnan(xmin_))
-    grid_points(0) = xmin_;
-  if (!std::isnan(xmax_))
-    grid_points(grid_points.size() - 1) = xmax_;
+  if (type_ == VarType::discrete) {
+    if (!std::isnan(xmin_))
+      grid_points(0) = xmin_;
+    if (!std::isnan(xmax_))
+      grid_points(grid_points.size() - 1) = xmax_;
+  }
 
   return grid_points;
 }

--- a/include/kde1d/tools.hpp
+++ b/include/kde1d/tools.hpp
@@ -118,6 +118,8 @@ linbin(const Eigen::VectorXd& x,
     if (li < num_bins) {
       gcnts(li) += (1 - rem) * weights(i);
       gcnts(li + 1) += rem * weights(i);
+    } else if (x(i) == upper) {
+      gcnts(num_bins) += weights(i);
     }
   }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -47,6 +47,36 @@ TEST_CASE("right extrapolation is continuous", "[interpolation]")
         Approx(3.0 * std::exp(-0.5)));
 }
 
+TEST_CASE("boundary grids resolve the transformed support", "[boundary-grid]")
+{
+  Eigen::VectorXd observations = Eigen::VectorXd::LinSpaced(200, 0.2, 0.8);
+  Kde1d bounded(0.0, 1.0, "continuous", 1.0, 0.3);
+  bounded.fit(observations);
+  Eigen::VectorXd grid = bounded.get_grid_points();
+
+  CHECK(grid(0) == Approx(0.0));
+  CHECK(grid(grid.size() - 1) == Approx(1.0));
+  CHECK(grid(1) < observations.minCoeff());
+  CHECK(grid(grid.size() - 2) > observations.maxCoeff());
+  CHECK((grid.tail(grid.size() - 1) - grid.head(grid.size() - 1)).minCoeff() >
+        0.0);
+
+  Kde1d left_bounded(0.0, NAN, "continuous", 1.0, 0.3);
+  left_bounded.fit(observations);
+  grid = left_bounded.get_grid_points();
+  CHECK(grid(0) == Approx(0.0));
+  CHECK(grid(1) < observations.minCoeff());
+  CHECK(grid(grid.size() - 1) > observations.maxCoeff());
+
+  observations *= -1.0;
+  Kde1d right_bounded(NAN, 0.0, "continuous", 1.0, 0.3);
+  right_bounded.fit(observations);
+  grid = right_bounded.get_grid_points();
+  CHECK(grid(0) < observations.minCoeff());
+  CHECK(grid(grid.size() - 2) > observations.maxCoeff());
+  CHECK(grid(grid.size() - 1) == Approx(0.0));
+}
+
 TEST_CASE("grid_size parameter", "[grid-size]")
 {
   

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -109,6 +109,17 @@ TEST_CASE("finite support truncates density", "[finite-support]")
   CHECK(density(3) == 0.0);
 }
 
+TEST_CASE("discrete CDF stays within the unit interval", "[discrete]")
+{
+  Eigen::VectorXd grid_points = Eigen::VectorXd::LinSpaced(10, 0.0, 9.0);
+  Eigen::VectorXd values = Eigen::VectorXd::Ones(10);
+  values(9) = 0.0;
+  interp::InterpolationGrid grid(grid_points, values, 0);
+  Kde1d discrete(grid, NAN, NAN, "discrete");
+
+  CHECK(discrete.cdf(Eigen::VectorXd::Constant(1, 8.0))(0) == 1.0);
+}
+
 TEST_CASE("likelihood summaries match fitted densities", "[likelihood]")
 {
   SECTION("weighted likelihood")

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -94,6 +94,21 @@ TEST_CASE("one-boundary fits are reflection equivariant", "[boundary-reflection]
   CHECK(left_bounded.get_edf() == Approx(right_bounded.get_edf()));
 }
 
+TEST_CASE("finite support truncates density", "[finite-support]")
+{
+  Eigen::VectorXd observations = Eigen::VectorXd::LinSpaced(200, 0.0, 1.0);
+  Kde1d bounded(0.0, 1.0, "continuous", 1.0, 0.5);
+  bounded.fit(observations);
+
+  Eigen::VectorXd evaluation_points(4);
+  evaluation_points << -1e-8, 0.0, 1.0, 1.0 + 1e-8;
+  Eigen::VectorXd density = bounded.pdf(evaluation_points);
+  CHECK(density(0) == 0.0);
+  CHECK(density(1) > 0.0);
+  CHECK(density(2) > 0.0);
+  CHECK(density(3) == 0.0);
+}
+
 TEST_CASE("grid_size parameter", "[grid-size]")
 {
   

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -33,6 +33,20 @@ TEST_CASE("linear binning includes the upper endpoint", "[linear-binning]")
   CHECK(counts.sum() == Approx(3.0));
 }
 
+TEST_CASE("right extrapolation is continuous", "[interpolation]")
+{
+  Eigen::VectorXd grid_points(2);
+  grid_points << 0.0, 1.0;
+  Eigen::VectorXd values(2);
+  values << 2.0, 3.0;
+  interp::InterpolationGrid grid(grid_points, values, 0);
+
+  CHECK(grid.interpolate(Eigen::VectorXd::Constant(1, 1.0))(0) ==
+        Approx(3.0));
+  CHECK(grid.interpolate(Eigen::VectorXd::Constant(1, 2.0))(0) ==
+        Approx(3.0 * std::exp(-0.5)));
+}
+
 TEST_CASE("grid_size parameter", "[grid-size]")
 {
   

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -144,8 +144,12 @@ TEST_CASE("likelihood summaries match fitted densities", "[likelihood]")
     Kde1d zero_inflated(0.0, NAN, "zero-inflated", 1.0, 0.5);
     zero_inflated.fit(observations);
 
-    CHECK(zero_inflated.get_loglik() ==
-          Approx(zero_inflated.pdf(observations).array().log().sum()));
+    Eigen::VectorXd density = zero_inflated.pdf(observations);
+    REQUIRE(zero_inflated.get_values().array().isFinite().all());
+    REQUIRE(density.array().isFinite().all());
+    REQUIRE((density.array() > 0.0).all());
+    REQUIRE(std::isfinite(zero_inflated.get_loglik()));
+    CHECK(zero_inflated.get_loglik() == Approx(density.array().log().sum()));
   }
 }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -109,6 +109,35 @@ TEST_CASE("finite support truncates density", "[finite-support]")
   CHECK(density(3) == 0.0);
 }
 
+TEST_CASE("likelihood summaries match fitted densities", "[likelihood]")
+{
+  SECTION("weighted likelihood")
+  {
+    Eigen::VectorXd observations = Eigen::VectorXd::LinSpaced(100, -2.0, 2.0);
+    Eigen::VectorXd weights = Eigen::VectorXd::LinSpaced(100, 0.5, 1.5);
+    Kde1d weighted(NAN, NAN, "continuous", 1.0, 0.5);
+    weighted.fit(observations, weights);
+
+    double expected =
+      (weighted.pdf(observations).array().log() * weights.array() /
+       weights.mean())
+        .sum();
+    CHECK(weighted.get_loglik() == Approx(expected));
+  }
+
+  SECTION("zero-inflated likelihood")
+  {
+    Eigen::VectorXd observations(100);
+    observations.head(40).setZero();
+    observations.tail(60) = Eigen::VectorXd::LinSpaced(60, 0.01, 3.0);
+    Kde1d zero_inflated(0.0, NAN, "zero-inflated", 1.0, 0.5);
+    zero_inflated.fit(observations);
+
+    CHECK(zero_inflated.get_loglik() ==
+          Approx(zero_inflated.pdf(observations).array().log().sum()));
+  }
+}
+
 TEST_CASE("grid_size parameter", "[grid-size]")
 {
   

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -77,6 +77,23 @@ TEST_CASE("boundary grids resolve the transformed support", "[boundary-grid]")
   CHECK(grid(grid.size() - 1) == Approx(0.0));
 }
 
+TEST_CASE("one-boundary fits are reflection equivariant", "[boundary-reflection]")
+{
+  Eigen::VectorXd observations = Eigen::VectorXd::LinSpaced(500, 0.01, 5.0);
+  Kde1d left_bounded(0.0, NAN, "continuous", 1.0, 0.5);
+  left_bounded.fit(observations);
+
+  Kde1d right_bounded(NAN, 0.0, "continuous", 1.0, 0.5);
+  right_bounded.fit(-observations);
+
+  CHECK(left_bounded.get_grid_points().isApprox(
+    -right_bounded.get_grid_points().reverse()));
+  CHECK(left_bounded.get_values().isApprox(
+    right_bounded.get_values().reverse()));
+  CHECK(left_bounded.get_loglik() == Approx(right_bounded.get_loglik()));
+  CHECK(left_bounded.get_edf() == Approx(right_bounded.get_edf()));
+}
+
 TEST_CASE("grid_size parameter", "[grid-size]")
 {
   

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -22,6 +22,17 @@ size_t nlevels = 50;
 Eigen::VectorXd x_d =
   (x_cb.array() * (static_cast<double>(nlevels) - 1)).round();
 
+TEST_CASE("linear binning includes the upper endpoint", "[linear-binning]")
+{
+  Eigen::VectorXd observations(3);
+  observations << 0.0, 0.5, 1.0;
+  Eigen::VectorXd counts = tools::linbin(
+    observations, 0.0, 1.0, 2, Eigen::VectorXd::Ones(3));
+
+  CHECK(counts.isApprox(Eigen::VectorXd::Ones(3)));
+  CHECK(counts.sum() == Approx(3.0));
+}
+
 TEST_CASE("grid_size parameter", "[grid-size]")
 {
   


### PR DESCRIPTION
## Summary

This ports the numerical repairs identified while testing the R frontend into the C++ backend where they can be tested and maintained directly.

The commits remain separated by defect:

- preserve observations exactly at the upper endpoint during linear binning;
- center right-tail interpolation at the right grid endpoint;
- construct continuous grids in transformed space so finite and one-sided supports are resolved correctly;
- align right-boundary influence values with the grid orientation;
- return zero density outside finite support bounds;
- clamp discrete CDF values to the unit interval after cumulative summation;
- stabilize negligible FFT tail values before local-polynomial divisions;
- add focused coverage for weighted and zero-inflated likelihood summaries.

The transformation-tail redesign is deliberately not included here; it remains the more speculative follow-up after these deterministic defects are settled.

## Verification

- GCC 12.3 release build
- 445 assertions in 16 Catch test cases

Each repair includes a direct C++ regression test.
