### PR TITLE
Speed up spline interpolation and integration

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,5 +23,6 @@ manual comparisons and never make CI pass or fail.
 
 Evaluation workloads use batches of 10, 100, 1,000, and 10,000 points. They
 cover interpolation and integration directly as well as the public PDF, CDF,
-and quantile paths, so an optimization can be checked for both its isolated
-effect and its end-to-end impact.
+and quantile paths. Grid construction is measured both alone and together with
+interpolation, so an evaluation optimization cannot hide an excessive setup
+cost.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -20,3 +20,8 @@ prints the current Git revision along with CMake's compiler information.
 
 The benchmark is deliberately not registered with CTest: timings are for
 manual comparisons and never make CI pass or fail.
+
+Evaluation workloads use batches of 10, 100, 1,000, and 10,000 points. They
+cover interpolation and integration directly as well as the public PDF, CDF,
+and quantile paths, so an optimization can be checked for both its isolated
+effect and its end-to-end impact.

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -2,6 +2,7 @@
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
 #include "catch.hpp"
 #include <kde1d.hpp>
+#include <array>
 
 TEST_CASE("continuous KDE performance", "[!benchmark]")
 {
@@ -44,23 +45,50 @@ TEST_CASE("continuous KDE performance", "[!benchmark]")
   unbounded_fit.fit(unbounded);
   kde1d::Kde1d bounded_fit(0.0, 1.0, "continuous", 1.0, 0.05, 2, 400);
   bounded_fit.fit(bounded);
-  Eigen::VectorXd unbounded_queries =
-    Eigen::VectorXd::LinSpaced(100000, -4.0, 4.0);
-  Eigen::VectorXd bounded_queries =
-    Eigen::VectorXd::LinSpaced(100000, 1e-8, 1.0 - 1e-8);
+  kde1d::interp::InterpolationGrid bounded_grid(bounded_fit.get_grid_points(),
+                                                bounded_fit.get_values(),
+                                                0);
 
-  BENCHMARK("evaluate/pdf/unbounded/tll/n=100000")
-  {
-    return unbounded_fit.pdf(unbounded_queries).sum();
-  };
+  for (Eigen::Index batch_size : std::array<Eigen::Index, 4>{ 10,
+                                                              100,
+                                                              1000,
+                                                              10000 }) {
+    Eigen::VectorXd unbounded_queries =
+      Eigen::VectorXd::LinSpaced(batch_size, -4.0, 4.0);
+    Eigen::VectorXd bounded_queries =
+      Eigen::VectorXd::LinSpaced(batch_size, 1e-8, 1.0 - 1e-8);
+    Eigen::VectorXd probabilities =
+      Eigen::VectorXd::LinSpaced(batch_size, 1e-4, 1.0 - 1e-4);
+    const std::string suffix = "/batch=" + std::to_string(batch_size);
 
-  BENCHMARK("evaluate/pdf/bounded/tll/n=100000")
-  {
-    return bounded_fit.pdf(bounded_queries).sum();
-  };
+    BENCHMARK("interpolation/interpolate/bounded" + suffix)
+    {
+      return bounded_grid.interpolate(bounded_queries).sum();
+    };
 
-  BENCHMARK("evaluate/cdf/bounded/tll/n=100000")
-  {
-    return bounded_fit.cdf(bounded_queries).sum();
-  };
+    BENCHMARK("interpolation/integrate/bounded" + suffix)
+    {
+      return bounded_grid.integrate(bounded_queries, true).sum();
+    };
+
+    BENCHMARK("evaluate/pdf/unbounded/tll" + suffix)
+    {
+      return unbounded_fit.pdf(unbounded_queries).sum();
+    };
+
+    BENCHMARK("evaluate/pdf/bounded/tll" + suffix)
+    {
+      return bounded_fit.pdf(bounded_queries).sum();
+    };
+
+    BENCHMARK("evaluate/cdf/bounded/tll" + suffix)
+    {
+      return bounded_fit.cdf(bounded_queries).sum();
+    };
+
+    BENCHMARK("evaluate/quantile/bounded/tll" + suffix)
+    {
+      return bounded_fit.quantile(probabilities).sum();
+    };
+  }
 }

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -45,9 +45,18 @@ TEST_CASE("continuous KDE performance", "[!benchmark]")
   unbounded_fit.fit(unbounded);
   kde1d::Kde1d bounded_fit(0.0, 1.0, "continuous", 1.0, 0.05, 2, 400);
   bounded_fit.fit(bounded);
-  kde1d::interp::InterpolationGrid bounded_grid(bounded_fit.get_grid_points(),
-                                                bounded_fit.get_values(),
-                                                0);
+  Eigen::VectorXd bounded_grid_points = bounded_fit.get_grid_points();
+  Eigen::VectorXd bounded_values = bounded_fit.get_values();
+  kde1d::interp::InterpolationGrid bounded_grid(
+    bounded_grid_points, bounded_values, 0);
+
+  BENCHMARK("interpolation/construct/bounded/m=400")
+  {
+    return kde1d::interp::InterpolationGrid(
+             bounded_grid_points, bounded_values, 0)
+      .get_values()
+      .sum();
+  };
 
   for (Eigen::Index batch_size : std::array<Eigen::Index, 4>{ 10,
                                                               100,
@@ -64,6 +73,13 @@ TEST_CASE("continuous KDE performance", "[!benchmark]")
     BENCHMARK("interpolation/interpolate/bounded" + suffix)
     {
       return bounded_grid.interpolate(bounded_queries).sum();
+    };
+
+    BENCHMARK("interpolation/construct-and-interpolate/bounded" + suffix)
+    {
+      kde1d::interp::InterpolationGrid grid(
+        bounded_grid_points, bounded_values, 0);
+      return grid.interpolate(bounded_queries).sum();
     };
 
     BENCHMARK("interpolation/integrate/bounded" + suffix)

--- a/include/kde1d/interpolation.hpp
+++ b/include/kde1d/interpolation.hpp
@@ -34,13 +34,13 @@ public:
 
 private:
   // Utility functions for spline Interpolation
-  double cubic_poly(const double& x, const Eigen::VectorXd& a) const;
-  double cubic_indef_integral(const double& x, const Eigen::VectorXd& a) const;
+  double cubic_poly(const double& x, const Eigen::Vector4d& a) const;
+  double cubic_indef_integral(const double& x, const Eigen::Vector4d& a) const;
   double cubic_integral(const double& lower,
                         const double& upper,
-                        const Eigen::VectorXd& a) const;
+                        const Eigen::Vector4d& a) const;
   size_t find_cell(const double& x0) const;
-  Eigen::VectorXd find_cell_coefs(const size_t& k) const;
+  Eigen::Vector4d find_cell_coefs(const size_t& k) const;
 
   Eigen::VectorXd grid_points_;
   Eigen::VectorXd values_;
@@ -83,7 +83,6 @@ InterpolationGrid::normalize(int times)
 inline Eigen::VectorXd
 InterpolationGrid::interpolate(const Eigen::VectorXd& x) const
 {
-  Eigen::VectorXd tmp_coefs(4);
   auto interpolate_one = [&](const double& xx) {
     size_t k = find_cell(xx);
     double xev =
@@ -113,7 +112,7 @@ InterpolationGrid::integrate(const Eigen::VectorXd& x, bool normalize) const
   auto ord = tools::get_order(x);
 
   // temporaries for the loop
-  Eigen::VectorXd tmp_coefs(4);
+  Eigen::Vector4d tmp_coefs;
   double new_int, tmp_eps, cum_int = 0.0;
   size_t k = 0, m = grid_points_.size();
   tmp_coefs = find_cell_coefs(0);
@@ -176,7 +175,7 @@ InterpolationGrid::integrate(const Eigen::VectorXd& x, bool normalize) const
 //! @param x evaluation point.
 //! @param a polynomial coefficients
 inline double
-InterpolationGrid::cubic_poly(const double& x, const Eigen::VectorXd& a) const
+InterpolationGrid::cubic_poly(const double& x, const Eigen::Vector4d& a) const
 {
   double x2 = x * x;
   double x3 = x2 * x;
@@ -189,7 +188,7 @@ InterpolationGrid::cubic_poly(const double& x, const Eigen::VectorXd& a) const
 //! @param a polynomial coefficients.
 inline double
 InterpolationGrid::cubic_indef_integral(const double& x,
-                                        const Eigen::VectorXd& a) const
+                                        const Eigen::Vector4d& a) const
 {
   double x2 = x * x;
   double x3 = x2 * x;
@@ -205,7 +204,7 @@ InterpolationGrid::cubic_indef_integral(const double& x,
 inline double
 InterpolationGrid::cubic_integral(const double& lower,
                                   const double& upper,
-                                  const Eigen::VectorXd& a) const
+                                  const Eigen::Vector4d& a) const
 {
   return cubic_indef_integral(upper, a) - cubic_indef_integral(lower, a);
 }
@@ -229,7 +228,7 @@ InterpolationGrid::find_cell(const double& x0) const
 //! Calculate coefficients for cubic intrpolation spline
 //!
 //! @param k the cell index.
-inline Eigen::VectorXd
+inline Eigen::Vector4d
 InterpolationGrid::find_cell_coefs(const size_t& k) const
 {
   // indices for cell and neighboring grid points
@@ -266,7 +265,7 @@ InterpolationGrid::find_cell_coefs(const size_t& k) const
   dx2 = std::min(dx2, 3 * values_(k2));
 
   // compute coefficents
-  Eigen::VectorXd a(4);
+  Eigen::Vector4d a;
   a(0) = values_(k);
   a(1) = dx1;
   a(2) = -3 * (values_(k) - values_(k2)) - 2 * dx1 - dx2;

--- a/include/kde1d/interpolation.hpp
+++ b/include/kde1d/interpolation.hpp
@@ -42,10 +42,12 @@ private:
   size_t find_cell(const double& x0) const;
   Eigen::Vector4d find_cell_coefs(const size_t& k) const;
   void update_cell_coefs();
+  void update_cumulative_integrals();
 
   Eigen::VectorXd grid_points_;
   Eigen::VectorXd values_;
   Eigen::Matrix<double, 4, Eigen::Dynamic> cell_coefs_;
+  Eigen::VectorXd cumulative_integrals_;
 };
 
 //! Constructor
@@ -72,13 +74,16 @@ inline InterpolationGrid::InterpolationGrid(const Eigen::VectorXd& grid_points,
 inline void
 InterpolationGrid::normalize(int times)
 {
-  double x_max = grid_points_(grid_points_.size() - 1);
-  double int_max;
   for (int k = 0; k < times; ++k) {
-    int_max = this->integrate(Eigen::VectorXd::Constant(1, x_max))(0);
-    values_ /= int_max;
+    double integral = 0.0;
+    for (Eigen::Index cell = 0; cell < grid_points_.size() - 1; ++cell) {
+      integral += cubic_integral(0.0, 1.0, find_cell_coefs(cell)) *
+                  (grid_points_(cell + 1) - grid_points_(cell));
+    }
+    values_ /= integral;
   }
   update_cell_coefs();
+  update_cumulative_integrals();
 }
 
 //! Interpolation
@@ -112,63 +117,26 @@ inline Eigen::VectorXd
 InterpolationGrid::integrate(const Eigen::VectorXd& x, bool normalize) const
 {
   Eigen::VectorXd res(x.size());
-  auto ord = tools::get_order(x);
-
-  // temporaries for the loop
-  Eigen::Vector4d tmp_coefs;
-  double new_int, tmp_eps, cum_int = 0.0;
-  size_t k = 0, m = grid_points_.size();
-  tmp_coefs = find_cell_coefs(0);
-  tmp_eps = (grid_points_(1) - grid_points_(0));
-
-  for (long i = 0; i < x.size(); ++i) {
-    double upr = x(ord(i));
-
-    if (std::isnan(upr)) {
-      res(ord(i)) = upr;
-      continue;
-    }
-    if (upr <= grid_points_(0)) {
-      res(ord(i)) = 0.0;
-      continue;
-    }
-
-    // go up the grid and integrate
-    while (k < m - 1) {
-      // halt loop if integration limit is in kth cell
-      if (upr < grid_points_(k + 1))
-        break;
-      // integrate over full cell
-      tmp_coefs = find_cell_coefs(k);
-      tmp_eps = (grid_points_(k + 1) - grid_points_(k));
-      cum_int += cubic_integral(0.0, 1.0, tmp_coefs) * tmp_eps;
-      k++;
-    }
-
-    // integrate over partial cell
-    if (upr < grid_points_(m - 1)) { // only if still in interior
-      tmp_coefs = find_cell_coefs(k);
-      tmp_eps = (grid_points_(k + 1) - grid_points_(k));
-      upr = (upr - grid_points_(k)) / tmp_eps;
-      new_int = cubic_integral(0.0, upr, tmp_coefs) * tmp_eps;
+  for (Eigen::Index i = 0; i < x.size(); ++i) {
+    if (std::isnan(x(i))) {
+      res(i) = x(i);
+    } else if (x(i) <= grid_points_(0)) {
+      res(i) = 0.0;
+    } else if (x(i) >= grid_points_(grid_points_.size() - 1)) {
+      res(i) = cumulative_integrals_(grid_points_.size() - 1);
     } else {
-      new_int = 0.0;
+      const size_t cell = find_cell(x(i));
+      const double cell_width = grid_points_(cell + 1) - grid_points_(cell);
+      const double position = (x(i) - grid_points_(cell)) / cell_width;
+      res(i) = cumulative_integrals_(cell) +
+               cubic_integral(
+                 0.0, position, Eigen::Vector4d(cell_coefs_.col(cell))) *
+                 cell_width;
     }
-
-    res(ord(i)) = cum_int + new_int;
   }
 
-  if (!normalize)
-    return res;
-
-  // integrate until end
-  while (k < m - 1) {
-    tmp_coefs = find_cell_coefs(k);
-    tmp_eps = (grid_points_(k + 1) - grid_points_(k));
-    cum_int += cubic_integral(0.0, 1.0, tmp_coefs) * tmp_eps;
-    k++;
-  }
-  return res / cum_int;
+  return normalize ? res / cumulative_integrals_(grid_points_.size() - 1)
+                   : res;
 }
 
 // ---------------- Utility functions for spline interpolation ----------------
@@ -283,6 +251,19 @@ InterpolationGrid::update_cell_coefs()
   cell_coefs_.resize(4, grid_points_.size() - 1);
   for (Eigen::Index k = 0; k < grid_points_.size() - 1; ++k)
     cell_coefs_.col(k) = find_cell_coefs(k);
+}
+
+inline void
+InterpolationGrid::update_cumulative_integrals()
+{
+  cumulative_integrals_ = Eigen::VectorXd::Zero(grid_points_.size());
+  for (Eigen::Index cell = 0; cell < grid_points_.size() - 1; ++cell) {
+    cumulative_integrals_(cell + 1) =
+      cumulative_integrals_(cell) +
+      cubic_integral(
+        0.0, 1.0, Eigen::Vector4d(cell_coefs_.col(cell))) *
+        (grid_points_(cell + 1) - grid_points_(cell));
+  }
 }
 
 } // end kde1d::interp

--- a/include/kde1d/interpolation.hpp
+++ b/include/kde1d/interpolation.hpp
@@ -41,9 +41,11 @@ private:
                         const Eigen::Vector4d& a) const;
   size_t find_cell(const double& x0) const;
   Eigen::Vector4d find_cell_coefs(const size_t& k) const;
+  void update_cell_coefs();
 
   Eigen::VectorXd grid_points_;
   Eigen::VectorXd values_;
+  Eigen::Matrix<double, 4, Eigen::Dynamic> cell_coefs_;
 };
 
 //! Constructor
@@ -76,6 +78,7 @@ InterpolationGrid::normalize(int times)
     int_max = this->integrate(Eigen::VectorXd::Constant(1, x_max))(0);
     values_ /= int_max;
   }
+  update_cell_coefs();
 }
 
 //! Interpolation
@@ -95,7 +98,7 @@ InterpolationGrid::interpolate(const Eigen::VectorXd& x) const
       return values_(k + 1) * std::exp(-0.5 * (xev - 1) * (xev - 1));
     }
 
-    return cubic_poly(xev, find_cell_coefs(k));
+    return cubic_poly(xev, Eigen::Vector4d(cell_coefs_.col(k)));
   };
 
   return tools::unaryExpr_or_nan(x, interpolate_one);
@@ -272,6 +275,14 @@ InterpolationGrid::find_cell_coefs(const size_t& k) const
   a(3) = 2 * (values_(k) - values_(k2)) + dx1 + dx2;
 
   return a;
+}
+
+inline void
+InterpolationGrid::update_cell_coefs()
+{
+  cell_coefs_.resize(4, grid_points_.size() - 1);
+  for (Eigen::Index k = 0; k < grid_points_.size() - 1; ++k)
+    cell_coefs_.col(k) = find_cell_coefs(k);
 }
 
 } // end kde1d::interp

--- a/include/kde1d/interpolation.hpp
+++ b/include/kde1d/interpolation.hpp
@@ -2,6 +2,7 @@
 
 #include "tools.hpp"
 #include <Eigen/Dense>
+#include <vector>
 
 namespace kde1d {
 
@@ -39,15 +40,18 @@ private:
   double cubic_integral(const double& lower,
                         const double& upper,
                         const Eigen::Vector4d& a) const;
-  size_t find_cell(const double& x0) const;
+  size_t binary_search(const double& x) const;
+  size_t find_cell(const double& x) const;
   Eigen::Vector4d find_cell_coefs(const size_t& k) const;
   void update_cell_coefs();
   void update_cumulative_integrals();
+  void update_cell_lookup();
 
   Eigen::VectorXd grid_points_;
   Eigen::VectorXd values_;
   Eigen::Matrix<double, 4, Eigen::Dynamic> cell_coefs_;
   Eigen::VectorXd cumulative_integrals_;
+  std::vector<size_t> cell_lookup_;
 };
 
 //! Constructor
@@ -66,6 +70,7 @@ inline InterpolationGrid::InterpolationGrid(const Eigen::VectorXd& grid_points,
   grid_points_ = grid_points;
   values_ = values;
   this->normalize(norm_times);
+  update_cell_lookup();
 }
 
 //! renormalizes the estimate to integrate to one
@@ -181,19 +186,39 @@ InterpolationGrid::cubic_integral(const double& lower,
 }
 
 inline size_t
-InterpolationGrid::find_cell(const double& x0) const
+InterpolationGrid::binary_search(const double& x) const
 {
   size_t low = 0, high = grid_points_.size() - 1;
   size_t mid;
   while (low < high - 1) {
     mid = low + (high - low) / 2;
-    if (x0 < grid_points_(mid))
+    if (x < grid_points_(mid))
       high = mid;
     else
       low = mid;
   }
 
   return low;
+}
+
+inline size_t
+InterpolationGrid::find_cell(const double& x) const
+{
+  const double relative_position =
+    (x - grid_points_(0)) /
+    (grid_points_(grid_points_.size() - 1) - grid_points_(0));
+  const double bounded_position =
+    std::min(std::max(relative_position, 0.0), 1.0);
+  const size_t bucket = std::min(
+    static_cast<size_t>(bounded_position *
+                        static_cast<double>(cell_lookup_.size())),
+    cell_lookup_.size() - 1);
+  size_t cell = cell_lookup_[bucket];
+  while ((cell < static_cast<size_t>(grid_points_.size() - 2)) &&
+         (grid_points_(cell + 1) <= x)) {
+    ++cell;
+  }
+  return cell;
 }
 
 //! Calculate coefficients for cubic intrpolation spline
@@ -263,6 +288,19 @@ InterpolationGrid::update_cumulative_integrals()
       cubic_integral(
         0.0, 1.0, Eigen::Vector4d(cell_coefs_.col(cell))) *
         (grid_points_(cell + 1) - grid_points_(cell));
+  }
+}
+
+inline void
+InterpolationGrid::update_cell_lookup()
+{
+  cell_lookup_.resize(128);
+  const double grid_range =
+    grid_points_(grid_points_.size() - 1) - grid_points_(0);
+  for (size_t bucket = 0; bucket < cell_lookup_.size(); ++bucket) {
+    cell_lookup_[bucket] = binary_search(
+      grid_points_(0) + grid_range * static_cast<double>(bucket) /
+                          static_cast<double>(cell_lookup_.size()));
   }
 }
 

--- a/include/kde1d/tools.hpp
+++ b/include/kde1d/tools.hpp
@@ -10,16 +10,20 @@ namespace tools {
 //! @param x function argument.
 //! @param func function to be applied.
 template<typename T>
-Eigen::MatrixXd
-unaryExpr_or_nan(const Eigen::MatrixXd& x, const T& func)
+Eigen::VectorXd
+unaryExpr_or_nan(const Eigen::Ref<const Eigen::VectorXd>& x, const T& func)
 {
-  return x.unaryExpr([&func](double y) {
-    if (std::isnan(y)) {
-      return std::numeric_limits<double>::quiet_NaN();
+  Eigen::VectorXd result(x.size());
+  const double* input = x.data();
+  double* output = result.data();
+  for (Eigen::Index i = 0; i < x.size(); ++i) {
+    if ((std::isnan)(input[i])) {
+      output[i] = std::numeric_limits<double>::quiet_NaN();
     } else {
-      return func(y);
+      output[i] = func(input[i]);
     }
-  });
+  }
+  return result;
 }
 
 //! computes the inverse \f$ f^{-1} \f$ of a function \f$ f \f$ by the

--- a/test/test_numerical_invariants.cpp
+++ b/test/test_numerical_invariants.cpp
@@ -76,3 +76,53 @@ TEST_CASE("continuous fits satisfy numerical invariants",
     }
   }
 }
+
+TEST_CASE("interpolation preserves nonuniform-grid reference values",
+          "[interpolation][parity]")
+{
+  Eigen::VectorXd grid_points(7);
+  grid_points << -2.0, -1.99, -1.2, -0.1, 0.0, 0.03, 2.5;
+  Eigen::VectorXd values(7);
+  values << 0.1, 0.8, 0.3, 1.2, 0.4, 1.1, 0.05;
+  Eigen::VectorXd queries(14);
+  queries << 2.5, -3.0, 0.015, -1.99, 1.1, -2.0, 3.0,
+    -0.1, -1.5, 0.0, 0.03, -1.2, -1.2, NAN;
+
+  kde1d::interp::InterpolationGrid grid(grid_points, values, 0);
+
+  Eigen::VectorXd expected_interpolation(13);
+  expected_interpolation << 0.05, 0.0, 0.72395374493927123, 0.8,
+    8.6024753616471621, 0.1, 0.048985984426542499, 1.2,
+    5.3485271720570431, 0.4, 1.1, 0.3, 0.3;
+  Eigen::VectorXd interpolation = grid.interpolate(queries);
+  CHECK(interpolation.head(13).isApprox(expected_interpolation, 1e-12));
+  CHECK(std::isnan(interpolation(13)));
+
+  Eigen::VectorXd expected_integral(13);
+  expected_integral << 18.813458606991869, 0.0, 5.6615750998365577,
+    0.0039240242616033786, 13.498277718530957, 0.0,
+    18.813458606991869, 5.5893705472445951, 3.3631171509959734,
+    5.6533162543153024, 5.6752953292140882, 4.0344600562080499,
+    4.0344600562080499;
+  Eigen::VectorXd integral = grid.integrate(queries);
+  CHECK(integral.head(13).isApprox(expected_integral, 1e-12));
+  CHECK(std::isnan(integral(13)));
+
+  Eigen::VectorXd expected_normalized_integral(13);
+  expected_normalized_integral << 1.0, 0.0, 0.30093217935656336,
+    0.00020857537912487005, 0.71747986377764861, 0.0, 1.0,
+    0.29709425916866511, 0.17876123796536264, 0.30049319332567026,
+    0.30166145671402017, 0.21444542125330829, 0.21444542125330829;
+  Eigen::VectorXd normalized_integral = grid.integrate(queries, true);
+  CHECK(normalized_integral.head(13).isApprox(expected_normalized_integral,
+                                               1e-12));
+  CHECK(std::isnan(normalized_integral(13)));
+
+  Eigen::VectorXd expected_normalized_values(7);
+  expected_normalized_values << 0.005315343770062343,
+    0.042522750160498744, 0.015946031310187028, 0.063784125240748113,
+    0.021261375080249372, 0.058468781470685779,
+    0.0026576718850311715;
+  kde1d::interp::InterpolationGrid normalized(grid_points, values, 3);
+  CHECK(normalized.get_values().isApprox(expected_normalized_values, 1e-12));
+}

--- a/test/test_numerical_invariants.cpp
+++ b/test/test_numerical_invariants.cpp
@@ -125,4 +125,11 @@ TEST_CASE("interpolation preserves nonuniform-grid reference values",
     0.0026576718850311715;
   kde1d::interp::InterpolationGrid normalized(grid_points, values, 3);
   CHECK(normalized.get_values().isApprox(expected_normalized_values, 1e-12));
+
+  grid.normalize(3);
+  CHECK(grid.get_values().isApprox(expected_normalized_values, 1e-12));
+  CHECK(grid.interpolate(queries).head(13).isApprox(
+    expected_interpolation / expected_integral(0), 1e-12));
+  CHECK(grid.integrate(queries).head(13).isApprox(
+    expected_normalized_integral, 1e-12));
 }


### PR DESCRIPTION
## Summary

This PR adapts the applicable performance ideas from vinecopulib PR #691 to the one-dimensional cubic interpolation backend. It is stacked on #30 and does not merge any branch.

- add golden parity fixtures for nonuniform grids, shuffled and duplicate queries, endpoints, extrapolation, NaNs, normalization, and cache refresh
- benchmark batches of 10, 100, 1,000, and 10,000 through interpolation, integration, PDF, CDF, and quantile paths
- use fixed-size four-element Eigen vectors for cubic coefficients
- replace the generic Eigen NaN wrapper with a vector-specific raw-pointer loop
- cache immutable spline coefficients and cumulative cell integrals
- replace per-call CDF sorting and spline rebuilding with cached prefix integration
- use a compact 128-entry cell lookup adapted to arbitrary support intervals

## Same-machine benchmark comparison

GNU 12.3, Release, 10 samples per workload. Values below are approximate speedup factors relative to commit 7a1d3da, before production optimizations.

| Workload | Batch 10 | Batch 100 | Batch 1,000 | Batch 10,000 |
| --- | ---: | ---: | ---: | ---: |
| interpolate | 3.6x | 4.0x | 4.8x | 4.0x |
| integrate | 50x | 12.5x | 4.0x | 3.2x |
| bounded PDF | 2.6x | 3.4x | 3.8x | 3.6x |
| bounded CDF | 50x | 12.5x | 3.7x | 3.2x |
| bounded quantile | 33x | 6.7x | 2.6x | 2.5x |

Fit workloads run approximately 1.4--2.1x as fast.

## Tradeoff

The caches are eager. Directly constructing a 400-point InterpolationGrid and evaluating only 10 or 100 points takes about 6.0 and 6.8 microseconds, versus 0.6 and 3.7 microseconds previously: approximately 10x and 1.8x as long. Construct-and-evaluate runs about 2.7x as fast at batch 1,000 and 3.8x as fast at 10,000. Normal Kde1d fits amortize setup immediately through likelihood evaluation and improve in every measured fit workload.

The original 1,024-bucket vinecopulib design made setup substantially worse here. This PR uses 128 buckets, reducing setup overhead while retaining evaluation gains.

## Validation

- Release CTest: both suites pass
- Strict Debug CTest: both suites pass
- Strict Release benchmark build: passes
- 1,127 assertions cover the existing behavior, numerical invariants, golden interpolation parity, and cache refresh after public normalize()
- six-platform CI is expected to run once for this stacked PR

## Commits

Each optimization is isolated for review and benchmarking:

1. parity fixtures and batch benchmarks
2. fixed-size spline coefficients
3. NaN-aware vector evaluation
4. coefficient cache
5. cumulative-integral cache
6. interpolation setup benchmark
7. compact cell lookup
8. normalization cache-refresh regression test

## Stack

- Base: #30
- This PR: performance optimizations
- No merges are requested yet.
