### PR TITLE
Speed up quantile inversion

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -22,7 +22,8 @@ The benchmark is deliberately not registered with CTest: timings are for
 manual comparisons and never make CI pass or fail.
 
 Evaluation workloads use batches of 10, 100, 1,000, and 10,000 points. They
-cover interpolation and integration directly as well as the public PDF, CDF,
-and quantile paths. Grid construction is measured both alone and together with
-interpolation, so an evaluation optimization cannot hide an excessive setup
-cost.
+cover interpolation and integration directly as well as the public PDF and CDF
+paths. Quantile timings cover bounded and unbounded continuous fits, discrete
+and zero-inflated fits, and the simulation path. Grid construction is measured
+both alone and together with interpolation, so an evaluation optimization
+cannot hide an excessive setup cost.

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -45,6 +45,13 @@ TEST_CASE("continuous KDE performance", "[!benchmark]")
   unbounded_fit.fit(unbounded);
   kde1d::Kde1d bounded_fit(0.0, 1.0, "continuous", 1.0, 0.05, 2, 400);
   bounded_fit.fit(bounded);
+  kde1d::Kde1d discrete_fit(0.0, 100.0, "discrete", 1.0, 2.0, 2, 400);
+  discrete_fit.fit((bounded.array() * 100.0).round());
+  Eigen::VectorXd zero_inflated = bounded;
+  zero_inflated.head(zero_inflated.size() / 4).setZero();
+  kde1d::Kde1d zero_inflated_fit(
+    0.0, 1.0, "zero-inflated", 1.0, 0.05, 2, 400);
+  zero_inflated_fit.fit(zero_inflated);
   Eigen::VectorXd bounded_grid_points = bounded_fit.get_grid_points();
   Eigen::VectorXd bounded_values = bounded_fit.get_values();
   kde1d::interp::InterpolationGrid bounded_grid(
@@ -105,6 +112,26 @@ TEST_CASE("continuous KDE performance", "[!benchmark]")
     BENCHMARK("evaluate/quantile/bounded/tll" + suffix)
     {
       return bounded_fit.quantile(probabilities).sum();
+    };
+
+    BENCHMARK("evaluate/quantile/unbounded/tll" + suffix)
+    {
+      return unbounded_fit.quantile(probabilities).sum();
+    };
+
+    BENCHMARK("evaluate/quantile/discrete/tll" + suffix)
+    {
+      return discrete_fit.quantile(probabilities).sum();
+    };
+
+    BENCHMARK("evaluate/quantile/zero-inflated/tll" + suffix)
+    {
+      return zero_inflated_fit.quantile(probabilities).sum();
+    };
+
+    BENCHMARK("evaluate/simulate/bounded/tll" + suffix)
+    {
+      return bounded_fit.simulate(batch_size, { 1 }).sum();
     };
   }
 }

--- a/include/kde1d/interpolation.hpp
+++ b/include/kde1d/interpolation.hpp
@@ -2,6 +2,7 @@
 
 #include "tools.hpp"
 #include <Eigen/Dense>
+#include <algorithm>
 #include <vector>
 
 namespace kde1d {
@@ -28,6 +29,8 @@ public:
   Eigen::VectorXd integrate(const Eigen::VectorXd& u,
                             bool normalize = false) const;
 
+  Eigen::VectorXd quantile(const Eigen::VectorXd& probabilities) const;
+
   Eigen::VectorXd get_values() const { return values_; }
   Eigen::VectorXd get_grid_points() const { return grid_points_; }
   double get_grid_max() const { return grid_points_[grid_points_.size() - 1]; }
@@ -40,6 +43,7 @@ private:
   double cubic_integral(const double& lower,
                         const double& upper,
                         const Eigen::Vector4d& a) const;
+  double invert_integral(double probability, double total_mass) const;
   size_t binary_search(const double& x) const;
   size_t find_cell(const double& x) const;
   Eigen::Vector4d find_cell_coefs(const size_t& k) const;
@@ -144,6 +148,22 @@ InterpolationGrid::integrate(const Eigen::VectorXd& x, bool normalize) const
                    : res;
 }
 
+//! Invert the normalized integral of the interpolation spline.
+//!
+//! @param probabilities vector of probabilities in the unit interval.
+inline Eigen::VectorXd
+InterpolationGrid::quantile(const Eigen::VectorXd& probabilities) const
+{
+  const double total_mass =
+    cumulative_integrals_(cumulative_integrals_.size() - 1);
+  if (!(total_mass > 0.0))
+    throw std::runtime_error("cannot invert a spline with non-positive mass");
+
+  return tools::unaryExpr_or_nan(probabilities, [&](const double probability) {
+    return invert_integral(probability, total_mass);
+  });
+}
+
 // ---------------- Utility functions for spline interpolation ----------------
 
 //! Evaluate a cubic polynomial
@@ -183,6 +203,67 @@ InterpolationGrid::cubic_integral(const double& lower,
                                   const Eigen::Vector4d& a) const
 {
   return cubic_indef_integral(upper, a) - cubic_indef_integral(lower, a);
+}
+
+inline double
+InterpolationGrid::invert_integral(double probability, double total_mass) const
+{
+  if (probability <= 0.0)
+    return grid_points_(0);
+  if (probability >= 1.0)
+    return grid_points_(grid_points_.size() - 1);
+
+  const double target_mass = probability * total_mass;
+
+  // Locate the spline cell containing the requested cumulative mass.
+  const double* upper_mass =
+    std::lower_bound(cumulative_integrals_.data() + 1,
+                     cumulative_integrals_.data() +
+                       cumulative_integrals_.size(),
+                     target_mass);
+  const Eigen::Index cell = std::min(
+    static_cast<Eigen::Index>(upper_mass - cumulative_integrals_.data() - 1),
+    grid_points_.size() - 2);
+  const double cell_width = grid_points_(cell + 1) - grid_points_(cell);
+  const double cell_mass =
+    cumulative_integrals_(cell + 1) - cumulative_integrals_(cell);
+  if (!(cell_mass > 0.0))
+    return grid_points_(cell + 1);
+
+  // Linear interpolation of cell mass is a cheap initial estimate.
+  double position = std::clamp(
+    (target_mass - cumulative_integrals_(cell)) / cell_mass, 0.0, 1.0);
+  double lower_position = 0.0;
+  double upper_position = 1.0;
+  const Eigen::Vector4d coefficients = cell_coefs_.col(cell);
+
+  for (int iteration = 0; iteration < 35; ++iteration) {
+    const double residual =
+      cubic_indef_integral(position, coefficients) * cell_width -
+      (target_mass - cumulative_integrals_(cell));
+    if (std::abs(residual) <=
+        8.0 * std::numeric_limits<double>::epsilon() * total_mass)
+      break;
+
+    if (residual < 0.0)
+      lower_position = position;
+    else
+      upper_position = position;
+
+    // Keep Newton steps inside the bracket; bisect when the density is flat.
+    const double derivative = cubic_poly(position, coefficients) * cell_width;
+    const double newton_position = derivative > 0.0
+                                     ? position - residual / derivative
+                                     : lower_position;
+    if ((derivative > 0.0) && (newton_position > lower_position) &&
+        (newton_position < upper_position)) {
+      position = newton_position;
+    } else {
+      position = 0.5 * (lower_position + upper_position);
+    }
+  }
+
+  return grid_points_(cell) + position * cell_width;
 }
 
 inline size_t

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -550,17 +550,7 @@ Kde1d::quantile(const Eigen::VectorXd& x, const bool& check_fitted) const
 inline Eigen::VectorXd
 Kde1d::quantile_continuous(const Eigen::VectorXd& x) const
 {
-  auto cdf = [&](const Eigen::VectorXd& xx) { return grid_.integrate(xx); };
-  auto q =
-    tools::invert_f(x, cdf, grid_.get_grid_min(), grid_.get_grid_max(), 35);
-
-  // replace with NaN where the input was NaN
-  for (long i = 0; i < x.size(); i++) {
-    if (std::isnan(x(i)))
-      q(i) = x(i);
-  }
-
-  return q;
+  return grid_.quantile(x);
 }
 
 inline Eigen::VectorXd
@@ -584,6 +574,9 @@ Kde1d::quantile_discrete(const Eigen::VectorXd& x) const
 inline Eigen::VectorXd
 Kde1d::quantile_zi(const Eigen::VectorXd& x) const
 {
+  if (prob0_ >= 1.0)
+    return tools::unaryExpr_or_nan(x, [](const double&) { return 0.0; });
+
   Eigen::VectorXd qs(x.size());
   auto p0 = this->cdf(Eigen::VectorXd::Zero(1), false)(0);
   auto newx = (x.array() <= p0 - prob0_)

--- a/include/kde1d/kde1d.hpp
+++ b/include/kde1d/kde1d.hpp
@@ -573,10 +573,9 @@ Kde1d::quantile_discrete(const Eigen::VectorXd& x) const
 
   auto p = cdf_discrete(lvs);
   auto quan = [&](const double& pp) {
-    size_t lv = 0;
-    while ((pp >= p(lv)) && (lv < nlevels - 1))
-      lv++;
-    return lvs(lv);
+    const double* level = std::lower_bound(p.data(), p.data() + p.size(), pp);
+    return lvs(std::min(static_cast<Eigen::Index>(level - p.data()),
+                        lvs.size() - 1));
   };
 
   return tools::unaryExpr_or_nan(x, quan);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -167,6 +167,9 @@ TEST_CASE("discrete quantiles satisfy the generalized inverse", "[quantile]")
          quantiles.head(quantiles.size() - 1))
           .minCoeff() >= 0.0);
   CHECK((cumulative.array() + 1e-14 >= probabilities.array()).all());
+
+  Eigen::VectorXd levels = Eigen::VectorXd::LinSpaced(4, 0.0, 3.0);
+  CHECK(fit.quantile(fit.cdf(levels)).isApprox(levels));
 }
 
 TEST_CASE("discrete CDF stays within the unit interval", "[discrete]")

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -47,6 +47,33 @@ TEST_CASE("right extrapolation is continuous", "[interpolation]")
         Approx(3.0 * std::exp(-0.5)));
 }
 
+TEST_CASE("spline quantiles invert nonuniform cumulative integrals",
+          "[interpolation][quantile]")
+{
+  Eigen::VectorXd grid_points(6);
+  grid_points << -2.0, -0.7, -0.1, 0.2, 0.9, 1.5;
+  Eigen::VectorXd values(6);
+  values << 0.05, 0.4, 1.2, 0.8, 0.3, 0.02;
+  interp::InterpolationGrid grid(grid_points, values, 1);
+
+  Eigen::VectorXd probabilities(10);
+  probabilities << 0.75, 1e-10, 0.25, 0.5, 1.0 - 1e-10, 0.25, 0.0, 1.0,
+    0.9, 0.1;
+  Eigen::VectorXd quantiles = grid.quantile(probabilities);
+  Eigen::VectorXd reference = tools::invert_f(
+    probabilities,
+    [&](const Eigen::VectorXd& x) { return grid.integrate(x, true); },
+    grid.get_grid_min(),
+    grid.get_grid_max(),
+    50);
+
+  CHECK(quantiles.isApprox(reference, 1e-10));
+  CHECK(grid.integrate(quantiles, true).isApprox(probabilities, 1e-12));
+  CHECK(quantiles(2) == quantiles(5));
+  CHECK(quantiles(6) == grid.get_grid_min());
+  CHECK(quantiles(7) == grid.get_grid_max());
+}
+
 TEST_CASE("boundary grids resolve the transformed support", "[boundary-grid]")
 {
   Eigen::VectorXd observations = Eigen::VectorXd::LinSpaced(200, 0.2, 0.8);
@@ -130,14 +157,15 @@ TEST_CASE("continuous quantiles invert the normalized CDF", "[quantile]")
     1.0;
   Eigen::VectorXd quantiles = fit.quantile(probabilities);
   Eigen::VectorXd round_trip = fit.cdf(quantiles);
+  CAPTURE(probabilities.transpose(),
+          quantiles.transpose(),
+          round_trip.transpose());
 
   CHECK((quantiles.tail(quantiles.size() - 1) -
          quantiles.head(quantiles.size() - 1))
           .minCoeff() >= 0.0);
   CHECK(quantiles(5) == quantiles(6));
-  // The current inverse uses the raw spline integral whereas cdf() normalizes
-  // it. Keep this loose enough to characterize that known discrepancy.
-  CHECK((round_trip - probabilities).cwiseAbs().maxCoeff() < 1e-5);
+  CHECK((round_trip - probabilities).cwiseAbs().maxCoeff() < 1e-8);
   CHECK(quantiles(0) >= 0.0);
   CHECK(quantiles(quantiles.size() - 1) <= 1.0);
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -109,6 +109,66 @@ TEST_CASE("finite support truncates density", "[finite-support]")
   CHECK(density(3) == 0.0);
 }
 
+TEST_CASE("continuous quantiles invert the normalized CDF", "[quantile]")
+{
+  Eigen::VectorXd observations = Eigen::VectorXd::LinSpaced(500, 0.0, 1.0);
+  Kde1d fit(0.0, 1.0, "continuous", 1.0, 0.1, 2, 400);
+  fit.fit(observations);
+
+  Eigen::VectorXd probabilities(12);
+  probabilities << 0.0,
+    1e-12,
+    1e-8,
+    1e-4,
+    0.1,
+    0.5,
+    0.5,
+    0.9,
+    1.0 - 1e-4,
+    1.0 - 1e-8,
+    1.0 - 1e-12,
+    1.0;
+  Eigen::VectorXd quantiles = fit.quantile(probabilities);
+  Eigen::VectorXd round_trip = fit.cdf(quantiles);
+
+  CHECK((quantiles.tail(quantiles.size() - 1) -
+         quantiles.head(quantiles.size() - 1))
+          .minCoeff() >= 0.0);
+  CHECK(quantiles(5) == quantiles(6));
+  // The current inverse uses the raw spline integral whereas cdf() normalizes
+  // it. Keep this loose enough to characterize that known discrepancy.
+  CHECK((round_trip - probabilities).cwiseAbs().maxCoeff() < 1e-5);
+  CHECK(quantiles(0) >= 0.0);
+  CHECK(quantiles(quantiles.size() - 1) <= 1.0);
+
+  Eigen::VectorXd shuffled(7);
+  shuffled << 0.9, NAN, 0.1, 0.9, 0.5, 0.1, NAN;
+  quantiles = fit.quantile(shuffled);
+  CHECK(std::isnan(quantiles(1)));
+  CHECK(std::isnan(quantiles(6)));
+  CHECK(quantiles(0) == quantiles(3));
+  CHECK(quantiles(2) == quantiles(5));
+}
+
+TEST_CASE("discrete quantiles satisfy the generalized inverse", "[quantile]")
+{
+  Eigen::VectorXd observations(10);
+  observations << 0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0;
+  Kde1d fit(0.0, 3.0, "discrete", 1.0, 0.5, 2, 100);
+  fit.fit(observations);
+
+  Eigen::VectorXd probabilities(9);
+  probabilities << 0.0, 1e-12, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0 - 1e-12, 1.0;
+  Eigen::VectorXd quantiles = fit.quantile(probabilities);
+  Eigen::VectorXd cumulative = fit.cdf(quantiles);
+
+  CHECK((quantiles.array() == quantiles.array().round()).all());
+  CHECK((quantiles.tail(quantiles.size() - 1) -
+         quantiles.head(quantiles.size() - 1))
+          .minCoeff() >= 0.0);
+  CHECK((cumulative.array() + 1e-14 >= probabilities.array()).all());
+}
+
 TEST_CASE("discrete CDF stays within the unit interval", "[discrete]")
 {
   Eigen::VectorXd grid_points = Eigen::VectorXd::LinSpaced(10, 0.0, 9.0);


### PR DESCRIPTION
## Summary

- expand quantile benchmarks to bounded and unbounded continuous, discrete,
  zero-inflated, and simulation workloads at batch sizes 10--10,000
- add endpoint, duplicate, shuffled-input, nonuniform-grid, round-trip, and
  generalized-inverse regression tests
- replace the linear scan for discrete quantiles with binary search and return
  the correct level when a probability equals a CDF jump
- replace 35 full CDF evaluations for every continuous quantile with one lookup
  in the cached cumulative integrals and a safeguarded Newton solve inside the
  selected spline cell
- invert the same normalized integral exposed by `cdf()` and preserve the
  degenerate all-zero zero-inflated model

## Issues identified

The continuous path discarded the cumulative-integral cache added in the parent
PR and instead bisected over the complete grid for 35 iterations. It also
inverted the raw spline integral while the public CDF normalizes that integral;
the new regression fixture measured a round-trip discrepancy of about 6.7e-6.

The discrete path scanned every level for every probability and advanced to the
next level when a probability exactly matched a CDF jump.

## Performance

Same-machine Release benchmarks, 10 samples per benchmark:

| batch | bounded quantile | speedup | bounded simulation | speedup |
|---:|---:|---:|---:|---:|
| 10 | 5.746 us -> 0.461 us | 12.5x | 21.514 us -> 15.656 us | 1.4x |
| 100 | 39.805 us -> 3.526 us | 11.3x | 54.370 us -> 18.550 us | 2.9x |
| 1,000 | 532.620 us -> 34.670 us | 15.4x | 671.293 us -> 62.755 us | 10.7x |
| 10,000 | 4.583 ms -> 0.314 ms | 14.6x | 7.615 ms -> 0.666 ms | 11.4x |

The discrete lookup runs approximately 1.1x, 1.6x, 2.6x, and 3.8x as fast at
the same batch sizes. Unbounded and zero-inflated continuous quantiles run
roughly 11.6--19.9x as fast.

## Validation

- Release CTest suite passes
- sanitizer-enabled Debug CTest suite passes
- direct spline inversion agrees with a 50-iteration normalized-CDF bisection
  reference on a nonuniform grid

This PR is stacked on #32.
